### PR TITLE
Allow the passing of URLs as filepaths to the GetVideoInfo method.

### DIFF
--- a/src/Alturos.VideoInfo.UnitTest/VideoInfoAnalyzerTest.cs
+++ b/src/Alturos.VideoInfo.UnitTest/VideoInfoAnalyzerTest.cs
@@ -79,5 +79,19 @@ namespace Alturos.VideoInfo.UnitTest
             Assert.IsTrue(anazlyeResult.Successful);
             Assert.AreEqual(120, anazlyeResult.VideoInfo.Format.Duration);
         }
+
+        [TestMethod]
+        public async Task GetVideoInfo_HTTPVideoURL_IsValid()
+        {
+            VideoAnalyzer videoAnalyzer = new VideoAnalyzer();
+            Assert.AreEqual(videoAnalyzer.IsValidURL("https://www.sample-videos.com/video123/mp4/240/big_buck_bunny_240p_1mb.mp4"), true);
+        }
+
+        [TestMethod]
+        public async Task GetVideoInfo_HTTPVideoURL_IsNotValid()
+        {
+            VideoAnalyzer videoAnalyzer = new VideoAnalyzer();
+            Assert.AreEqual(videoAnalyzer.IsValidURL("ftp://www.sample-videos.com/video123/mp4/240/big_buck_bunny_240p_1mb.mp4"), false);
+        }
     }
 }

--- a/src/Alturos.VideoInfo/VideoAnalyzer.cs
+++ b/src/Alturos.VideoInfo/VideoAnalyzer.cs
@@ -3,9 +3,13 @@ using Newtonsoft.Json.Serialization;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Alturos.VideoInfo.UnitTest")]
 namespace Alturos.VideoInfo
 {
     public class VideoAnalyzer
@@ -44,7 +48,10 @@ namespace Alturos.VideoInfo
         {
             if (!File.Exists(videoFilePath))
             {
-                return new AnalyzeResult { Successful = false, ErrorMessage = "File does not exist" };
+                if (!IsValidURL(videoFilePath))
+                {
+                    return new AnalyzeResult { Successful = false, ErrorMessage = "File does not exist" };
+                }
             }
 
             if (!File.Exists(this._ffprobePath))
@@ -102,6 +109,58 @@ namespace Alturos.VideoInfo
                     process.OutputDataReceived -= dataReceived;
                     process?.Dispose();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Validate that a URL meets the pattern for a URL, and then attempt to retrieve the resource from the URL
+        /// </summary>
+        /// <param name="url">The URL to validate</param>
+        /// <returns></returns>
+        internal bool IsValidURL(string url)
+        {
+            //https://stackoverflow.com/questions/5717312/regular-expression-for-url
+            string Pattern = @"^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$";
+            Regex Rgx = new Regex(Pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+            //https://stackoverflow.com/questions/924679/c-sharp-how-can-i-check-if-a-url-exists-is-valid
+            if (Rgx.IsMatch(url))
+            {
+                try
+                {
+                    HttpWebRequest request = HttpWebRequest.Create(url) as HttpWebRequest;
+                    request.Timeout = 5000; //set the timeout to 5 seconds to keep the user from waiting too long for the page to load
+                    request.Method = "HEAD"; //Get only the header information -- no need to download any content
+
+                    using (HttpWebResponse response = request.GetResponse() as HttpWebResponse)
+                    {
+                        int statusCode = (int)response.StatusCode;
+                        if (statusCode >= 100 && statusCode < 400) //Good requests
+                        {
+                            return true;
+                        }
+                        else if (statusCode >= 500 && statusCode <= 510) //Server Errors
+                        {
+                            return false;
+                        }
+                    }
+                }
+                catch (WebException ex)
+                {
+                    if (ex.Status == WebExceptionStatus.ProtocolError) //400 errors
+                    {
+                        return false;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    return false;
+                }
+                return false;
+            }
+            else
+            {
+                return false;
             }
         }
     }


### PR DESCRIPTION
Found your wrapper very useful but I needed to extract metadata from video's hosted on a web servers. The ffprobe.exe can handle passing a URL and not just a local file so I have modified the library to allow this. 

If you are happy to merge and create a new NuGet build I would appreciate it. 